### PR TITLE
Build fixes for modern GCC (C23 default, stricter pointer types)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ project (xdisp C)
 
 cmake_minimum_required(VERSION 3.10)
 
+# Vintage X11 widget code (olgx, EZWGL) uses K&R-style empty () prototypes.
+# C23 (GCC 15+ default) treats () as (void), breaking calls with arguments.
+# Compile xdisp as C17 where () still means "unspecified arguments".
+set(CMAKE_C_STANDARD 17)
+
 
 SET(XDISP_PACKAGE_VERSION_MAJOR 4)
 SET(XDISP_PACKAGE_VERSION_MINOR 3)

--- a/handler.c
+++ b/handler.c
@@ -223,7 +223,7 @@ void HandleEvent(XEvent *event)
   }
   /* button press events */
   if (XFindContext(theDisp, event->xany.window, xwin_context,
-		   (void * *) &which_xwin)==0) {
+		   (XPointer *) &which_xwin)==0) {
     if(*(which_xwin->event_handler)!=NULL)
       (*(which_xwin->event_handler))(which_xwin);
     if (Scale_Data && (oUpper != Upper || oLower != Lower)) {


### PR DESCRIPTION
GCC 15+ defaults to C23, which interprets empty `()` prototypes as
`(void)` instead of K&R unspecified-args. `olgx` and `EZWGL` are
vintage X11 widget code (1990s) that uses `()` everywhere; calls with
arguments now fail to compile under the default standard.

- Set `CMAKE_C_STANDARD 17` at the xdisp top level so all subdirs build
  with C17 semantics where `()` remains "unspecified arguments".
- Fix one real type-strictness issue in `handler.c`: `XFindContext`
  expects `XPointer *` (= `char **`) for its data return, not
  `(void **)`. Modern GCC enforces this via
  `-Werror=incompatible-pointer-types`.

Verified: xdisp builds cleanly under GCC 16.1; full minc-toolkit-v2
superbuild reaches 100%.