### PR TITLE
EZWGL: fix K&R int (*)() decls for GCC 15 / C23 compatibility

### DIFF
--- a/EZWGL-1.50/lib/EZ_Comm.c
+++ b/EZWGL-1.50/lib/EZ_Comm.c
@@ -273,7 +273,7 @@ void EZ_RegisterApplication()
 unsigned long EZ_VerifyExistence(commWindow)
      Window commWindow;
 {
-  int    (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   Atom          aType;
   int           aFormat = 0, ans;
   char          *data = NULL;
@@ -312,7 +312,7 @@ unsigned long EZ_VerifyExistence(commWindow)
 unsigned long EZ_WindowIsDnDTarget(dndWindow)
      Window dndWindow;
 {
-  int    (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   Atom          aType;
   int           aFormat = 0, ans;
   unsigned long ret = 0L;
@@ -347,7 +347,7 @@ unsigned long EZ_WindowIsDnDTarget(dndWindow)
 unsigned long EZ_WindowIsDnDSrc(dndWindow)
      Window dndWindow;
 {
-  int    (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   Atom          aType;
   int           aFormat = 0, ans;
   unsigned long ret = 0L;
@@ -390,7 +390,7 @@ int  EZ_WindowExist(window)
   Window parent_return;
   unsigned int nchildren_return;
   Window *children_return = (Window *)NULL;
-  int    (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
 
   if(window)
     {
@@ -464,7 +464,7 @@ int EZ_SendEmbedingMessage(type, fmdummy, fmwin, fwidget, todummy, towin,twidget
 {
   EZ_EmbedingMessage theMsg;     
   char message[256];           /* this is big enough !*/
-  int  (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
 
   theMsg.type = type;
   theMsg.fmCommWin =  (unsigned long)fmdummy;
@@ -503,7 +503,7 @@ int EZ_GetWindowProperty(dummyWin, prop_type, data_ret, length_ret, remove)
      unsigned long *length_ret;
      int   remove;
 {
-  int    (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   Atom          aType;
   int           aFormat = 0, ans;
   unsigned long bytesAfter, totalBytes = 0;
@@ -951,7 +951,7 @@ void EZ_GenerateEmbedingRequest(widget, x,y,w,h)
   char *p, *q;
   int length;
   EZ_ApplRoster *roster;
-  int    (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   
   theMsg.type = EZ_EMBEDING_REQUEST_S;
   theMsg.id = EZ_ApplicationSetupTime;

--- a/EZWGL-1.50/lib/EZ_Message.c
+++ b/EZWGL-1.50/lib/EZ_Message.c
@@ -312,7 +312,7 @@ void EZ_SendMessage(mtype, message, length, mId, recipient, replyId, isA)
   EZ_ApplRoster  *roster;
   Window         window;
   char           *p, *q, *msg;
-  int           (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   Atom  rclass, rinstance;
 
   msg = (char *)my_malloc((length+EZ_MSG_HEADER_LENGTH+1)*sizeof(char), _C_MESSAGE_);


### PR DESCRIPTION
## Summary

Under GCC 15 (Fedora 42/43/44 default), C23 mode treats K&R empty parens `()` as `(void)` rather than "unspecified args". The K&R declarations

```c
int    (*OldErrorHandler)();
```

in `EZWGL-1.50/lib/EZ_Comm.c` (×7) and `EZWGL-1.50/lib/EZ_Message.c` (×1) then become incompatible with the return type of `XSetErrorHandler()`, which is `XErrorHandler = int (*)(Display *, XErrorEvent *)`. The build fails with:

```
EZ_Message.c:351:31: error: assignment to 'int (*)(void)' from incompatible
pointer type 'XErrorHandler' {aka 'int (*)(Display *, XErrorEvent *)'}
[-Wincompatible-pointer-types]
```

Replace the K&R declarations with the Xlib-supplied `XErrorHandler` typedef. No behavioural change; this just fixes the type mismatch and is portable to K&R through C23.

## Test plan
- [ ] Build minc-toolkit-v2 superbuild with `MT_BUILD_VISUAL_TOOLS=ON` on Fedora 42/43/44 (GCC 15)
- [ ] Confirm existing builds on Ubuntu 22.04 / 24.04 and Debian 11 / 12 continue to pass