### PR TITLE
EZWGL: extend K&R OldErrorHandler typedef fix to remaining 8 files

### DIFF
--- a/EZWGL-1.50/lib/EZ_Cursor.c
+++ b/EZWGL-1.50/lib/EZ_Cursor.c
@@ -191,7 +191,7 @@ void EZ_NormalCursor(widget)
 static Cursor installCursor(pixmap, mask, fg, bg, xx,yy, name, idx_ret)
      Pixmap pixmap, mask; char *fg, *bg, *name; int xx, yy; int *idx_ret;
 {
-  int    (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   XColor fgc, bgc;
   Cursor cursor = None;
   int vvv = -1;

--- a/EZWGL-1.50/lib/EZ_DnD.c
+++ b/EZWGL-1.50/lib/EZ_DnD.c
@@ -215,7 +215,7 @@ void EZ_RemveWidgetFromDnDList(widget)
 /***************************************************************************************/
 void EZ_GrabButtonRelease()
 {
-  int    (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   Window         cwindow;
   char           *p, *q;
   EZ_ApplRoster *roster = EZ_OpenEZWGLRoster(0);
@@ -277,7 +277,7 @@ void EZ_GrabButtonRelease()
 /***************************************************************************************/
 void EZ_UngrabButtonRelease()
 {
-  int    (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   Window         cwindow;
   char           *p, *q;
   EZ_ApplRoster *roster = EZ_OpenEZWGLRoster(0);
@@ -1575,7 +1575,7 @@ void EZ_SelectInput(win, mask) Window win; long mask;
         }
       if(doit)
         {
-          int    (*OldErrorHandler)();
+          XErrorHandler OldErrorHandler;
           OldErrorHandler = XSetErrorHandler(EZ_XErrorHandler);
           XSelectInput(EZ_Display, win, mask);
           XSetErrorHandler(OldErrorHandler);            

--- a/EZWGL-1.50/lib/EZ_DnDMsg.c
+++ b/EZWGL-1.50/lib/EZ_DnDMsg.c
@@ -86,7 +86,7 @@ void EZ_SendDnDMessage(type, message, length, needFree)
      char *message;
      int length, needFree;
 {
-  int  (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   Window receiver;
   EZ_EncodeDnDMessageHeader(type, message, length, &receiver);  /* attach addresses */
 
@@ -146,7 +146,7 @@ void EZ_BroadcastDnDMessage(type, message, length, needFree)
   EZ_ApplRoster *roster;
   Window         window;
   char           *p, *q;
-  int  (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   (void)EZ_EncodeDnDMessageHeader(type, message, length, &window);
   roster = EZ_OpenEZWGLRoster(0);  /* grab the server remoced 5-19-97 */
   for(p = roster->data; (p - roster->data) < roster->length;)

--- a/EZWGL-1.50/lib/EZ_Widget3DCanvas.c
+++ b/EZWGL-1.50/lib/EZ_Widget3DCanvas.c
@@ -367,7 +367,7 @@ void EZ_Get3DCanvasSize(canvas, w_ret, h_ret)
 XImage *EZ_ReadDrawable2XImage(drawable, x, y, w, h)
      Drawable drawable; int x, y, w, h;
 {
-  int    (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   XImage *image;
 
   EZ_XErrorCode = 0;

--- a/EZWGL-1.50/lib/EZ_WidgetEmbeder.c
+++ b/EZWGL-1.50/lib/EZ_WidgetEmbeder.c
@@ -826,7 +826,7 @@ int EZ_MakeSnapShot(widget, type, XX,YY,WW,HH)
      EZ_Widget * widget; 
      int type,XX,YY,WW,HH;
 {
-  int    (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   XImage *image;
   Pixmap pixmap=(Pixmap)NULL;
   int  x,y, w,h; 

--- a/EZWGL-1.50/lib/EZ_WidgetFont.c
+++ b/EZWGL-1.50/lib/EZ_WidgetFont.c
@@ -148,7 +148,7 @@ int EZ_FontWeightIsBold(name)
 void  EZ_InitFontList()
 {
   register int  i;  
-  int    (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   
   OldErrorHandler = XSetErrorHandler(EZ_XErrorHandler);
   

--- a/EZWGL-1.50/lib/EZ_WidgetInit.c
+++ b/EZWGL-1.50/lib/EZ_WidgetInit.c
@@ -1068,7 +1068,7 @@ int EZ_QueryPixelValue(widget, x, y, pv)
       if(x >= 0 && x < EZ_WidgetWidth(widget) && 
          y >=0 && y <= EZ_WidgetHeight(widget))
         {
-          int    (*OldErrorHandler)();
+          XErrorHandler OldErrorHandler;
           XImage *image;
           EZ_XErrorCode = 0;
           OldErrorHandler = XSetErrorHandler(EZ_XErrorHandler);

--- a/EZWGL-1.50/lib/EZ_WidgetMisc.c
+++ b/EZWGL-1.50/lib/EZ_WidgetMisc.c
@@ -85,7 +85,7 @@ Window EZ_FindClientWindow(win)
     unsigned char *data;
     Window        inf;
     Display       *dpy = EZ_Display;
-    int            (*OldErrorHandler)();
+    XErrorHandler OldErrorHandler;
       
     WM_STATE = XInternAtom(dpy, "WM_STATE", True);
     if(!WM_STATE) return win;


### PR DESCRIPTION
Follow-up to #6.

PR #6 fixed `EZ_Comm.c` and `EZ_Message.c`, but local build with GCC 16 (which also defaults to C23) caught 9 more instances of the same `int (*OldErrorHandler)();` K&R pattern that weren't reached because the Fedora CI parallel build aborted early on the first error.

Affected files (1 instance each unless noted):
- `EZ_DnD.c` (3)
- `EZ_DnDMsg.c` (2)
- `EZ_Cursor.c`
- `EZ_Widget3DCanvas.c`
- `EZ_WidgetFont.c`
- `EZ_WidgetEmbeder.c`
- `EZ_WidgetInit.c`
- `EZ_WidgetMisc.c`

Same mechanical change as #6: `int (*OldErrorHandler)();` → `XErrorHandler OldErrorHandler;` so the assignment from `XSetErrorHandler()` (`int (*)(Display *, XErrorEvent *)`) is a type match under C23, where empty parens now mean `(void)`.

Tested locally on Arch Linux with GCC 16.1.1 — xdisp target builds clean after this change.