### PR TITLE
xdisp: modern-toolchain build fixes (C23, handler.c, EZWGL/olgx)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,17 @@ project (xdisp C)
 
 cmake_minimum_required(VERSION 3.10)
 
+# Build the vintage olgx/EZWGL widget code (1990s C) on modern toolchains:
+# - C11 (not the GCC 15+ C23 default) so empty () prototypes keep K&R
+#   unspecified-args semantics. C11 (not C17) for CMake 3.18 (Debian 11).
+# - gnu extensions so platform headers expose POSIX/BSD types the code uses
+#   (e.g. macOS <net/if.h> only declares u_char under _DARWIN_C_SOURCE).
+# - downgrade implicit-function-declaration (e.g. gethostname) from error to
+#   warning; modern clang makes it fatal by default.
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_EXTENSIONS ON)
+add_compile_options(-Wno-error=implicit-function-declaration)
+
 
 SET(XDISP_PACKAGE_VERSION_MAJOR 4)
 SET(XDISP_PACKAGE_VERSION_MINOR 3)

--- a/EZWGL-1.50/lib/EZ_Cursor.c
+++ b/EZWGL-1.50/lib/EZ_Cursor.c
@@ -191,7 +191,7 @@ void EZ_NormalCursor(widget)
 static Cursor installCursor(pixmap, mask, fg, bg, xx,yy, name, idx_ret)
      Pixmap pixmap, mask; char *fg, *bg, *name; int xx, yy; int *idx_ret;
 {
-  int    (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   XColor fgc, bgc;
   Cursor cursor = None;
   int vvv = -1;

--- a/EZWGL-1.50/lib/EZ_DnD.c
+++ b/EZWGL-1.50/lib/EZ_DnD.c
@@ -215,7 +215,7 @@ void EZ_RemveWidgetFromDnDList(widget)
 /***************************************************************************************/
 void EZ_GrabButtonRelease()
 {
-  int    (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   Window         cwindow;
   char           *p, *q;
   EZ_ApplRoster *roster = EZ_OpenEZWGLRoster(0);
@@ -277,7 +277,7 @@ void EZ_GrabButtonRelease()
 /***************************************************************************************/
 void EZ_UngrabButtonRelease()
 {
-  int    (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   Window         cwindow;
   char           *p, *q;
   EZ_ApplRoster *roster = EZ_OpenEZWGLRoster(0);
@@ -1575,7 +1575,7 @@ void EZ_SelectInput(win, mask) Window win; long mask;
         }
       if(doit)
         {
-          int    (*OldErrorHandler)();
+          XErrorHandler OldErrorHandler;
           OldErrorHandler = XSetErrorHandler(EZ_XErrorHandler);
           XSelectInput(EZ_Display, win, mask);
           XSetErrorHandler(OldErrorHandler);            

--- a/EZWGL-1.50/lib/EZ_DnDMsg.c
+++ b/EZWGL-1.50/lib/EZ_DnDMsg.c
@@ -86,7 +86,7 @@ void EZ_SendDnDMessage(type, message, length, needFree)
      char *message;
      int length, needFree;
 {
-  int  (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   Window receiver;
   EZ_EncodeDnDMessageHeader(type, message, length, &receiver);  /* attach addresses */
 
@@ -146,7 +146,7 @@ void EZ_BroadcastDnDMessage(type, message, length, needFree)
   EZ_ApplRoster *roster;
   Window         window;
   char           *p, *q;
-  int  (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   (void)EZ_EncodeDnDMessageHeader(type, message, length, &window);
   roster = EZ_OpenEZWGLRoster(0);  /* grab the server remoced 5-19-97 */
   for(p = roster->data; (p - roster->data) < roster->length;)

--- a/EZWGL-1.50/lib/EZ_Widget3DCanvas.c
+++ b/EZWGL-1.50/lib/EZ_Widget3DCanvas.c
@@ -367,7 +367,7 @@ void EZ_Get3DCanvasSize(canvas, w_ret, h_ret)
 XImage *EZ_ReadDrawable2XImage(drawable, x, y, w, h)
      Drawable drawable; int x, y, w, h;
 {
-  int    (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   XImage *image;
 
   EZ_XErrorCode = 0;

--- a/EZWGL-1.50/lib/EZ_WidgetEmbeder.c
+++ b/EZWGL-1.50/lib/EZ_WidgetEmbeder.c
@@ -826,7 +826,7 @@ int EZ_MakeSnapShot(widget, type, XX,YY,WW,HH)
      EZ_Widget * widget; 
      int type,XX,YY,WW,HH;
 {
-  int    (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   XImage *image;
   Pixmap pixmap=(Pixmap)NULL;
   int  x,y, w,h; 

--- a/EZWGL-1.50/lib/EZ_WidgetFont.c
+++ b/EZWGL-1.50/lib/EZ_WidgetFont.c
@@ -148,7 +148,7 @@ int EZ_FontWeightIsBold(name)
 void  EZ_InitFontList()
 {
   register int  i;  
-  int    (*OldErrorHandler)();
+  XErrorHandler OldErrorHandler;
   
   OldErrorHandler = XSetErrorHandler(EZ_XErrorHandler);
   

--- a/EZWGL-1.50/lib/EZ_WidgetInit.c
+++ b/EZWGL-1.50/lib/EZ_WidgetInit.c
@@ -1068,7 +1068,7 @@ int EZ_QueryPixelValue(widget, x, y, pv)
       if(x >= 0 && x < EZ_WidgetWidth(widget) && 
          y >=0 && y <= EZ_WidgetHeight(widget))
         {
-          int    (*OldErrorHandler)();
+          XErrorHandler OldErrorHandler;
           XImage *image;
           EZ_XErrorCode = 0;
           OldErrorHandler = XSetErrorHandler(EZ_XErrorHandler);

--- a/EZWGL-1.50/lib/EZ_WidgetMisc.c
+++ b/EZWGL-1.50/lib/EZ_WidgetMisc.c
@@ -85,7 +85,7 @@ Window EZ_FindClientWindow(win)
     unsigned char *data;
     Window        inf;
     Display       *dpy = EZ_Display;
-    int            (*OldErrorHandler)();
+    XErrorHandler OldErrorHandler;
       
     WM_STATE = XInternAtom(dpy, "WM_STATE", True);
     if(!WM_STATE) return win;

--- a/handler.c
+++ b/handler.c
@@ -223,7 +223,7 @@ void HandleEvent(XEvent *event)
   }
   /* button press events */
   if (XFindContext(theDisp, event->xany.window, xwin_context,
-		   (void * *) &which_xwin)==0) {
+		   (XPointer *) &which_xwin)==0) {
     if(*(which_xwin->event_handler)!=NULL)
       (*(which_xwin->event_handler))(which_xwin);
     if (Scale_Data && (oUpper != Upper || oLower != Lower)) {


### PR DESCRIPTION
olgx and EZWGL are 1990s C that fail under current compilers/SDKs:

- **C23 default** (GCC 15+): empty `()` prototypes are treated as `(void)`, breaking K&R-style calls with arguments. Pin `CMAKE_C_STANDARD 11` (C11, not C17, so CMake 3.18 / Debian 11 accepts the value).
- **strict-ISO hides platform types**: keep `CMAKE_C_EXTENSIONS ON` (gnu11) so headers expose POSIX/BSD types the code relies on — e.g. macOS `<net/if.h>` only declares `u_char` under `_DARWIN_C_SOURCE`.
- **implicit function declarations** (e.g. `gethostname`): downgrade from error to warning; modern clang makes them fatal by default. The calls are ABI-compatible int-returning libc functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)