### PR TITLE
EZWGL: include <fcntl.h> in EZ_ITermComm.c for macOS

### DIFF
--- a/EZWGL-1.50/lib/EZ_ITermComm.c
+++ b/EZWGL-1.50/lib/EZ_ITermComm.c
@@ -69,6 +69,10 @@
 
 #include "EZ_Widget.h"
 
+/* O_NDELAY / O_RDWR / F_SETFL live in <fcntl.h>. Linux pulls it in
+ * transitively, but macOS does not, so include it explicitly. */
+#include <fcntl.h>
+
 /* Consistent defines - please report on the necessity
  * @ Unixware: defines (__svr4__)
  */


### PR DESCRIPTION
`EZ_ITermComm.c` uses `O_NDELAY`, `O_RDWR`, `F_SETFL` (declared in `<fcntl.h>`) but only included `<termios.h>`. On Linux `<fcntl.h>` is pulled in transitively; on macOS it is not, so the build fails:

```
EZWGL-1.50/lib/EZ_ITermComm.c:639: error: use of undeclared identifier 'O_NDELAY'
```

Include `<fcntl.h>` explicitly. Correct on all platforms.

Surfaced once the macOS build progressed past HDF5 (now resolving libhdf5/libhdf5_cpp) into the xdisp/EZWGL compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)